### PR TITLE
export `mk_msg` and `mk_msgs`

### DIFF
--- a/00_core.ipynb
+++ b/00_core.ipynb
@@ -72,6 +72,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "6459c998",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| export\n",
+    "_all_ = ['mk_msg', 'mk_msgs']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "f5fa6b92",
    "metadata": {},
    "outputs": [],
@@ -488,7 +499,7 @@
    ],
    "source": [
     "prompt = \"I'm Jeremy\"\n",
-    "m = mk_msg(prompt, text_only=True)\n",
+    "m = mk_msg(prompt)\n",
     "r = cli.create(messages=[m], model=model, max_completion_tokens=100)\n",
     "r"
    ]
@@ -498,38 +509,21 @@
    "id": "6c7b389b",
    "metadata": {},
    "source": [
-    "We can pass more than just text messages to OpenAI. We can also pass images, SDK objects, etc. To handle these different data types we need to pass the type along with our content to OpenAI. \n",
+    "We can pass more than just text messages to OpenAI. As we'll see later we can also pass images, SDK objects, etc. To handle these different data types we need to pass the type along with our content to OpenAI. \n",
+    "\n",
+    "Here's an example of a multimodal message containing text and images. \n",
     "\n",
     "```json\n",
-    "{'role': 'user', 'content': [{'type': 'text', 'text': \"I'm Jeremy\"}]}\n",
+    "{\n",
+    "    'role': 'user', \n",
+    "    'content': [\n",
+    "        {'type': 'text', 'text': 'What is in the image?'},\n",
+    "        {'type': 'image_url', 'image_url': {'url': f'data:{MEDIA_TYPE};base64,{IMG}'}}\n",
+    "    ]\n",
+    "}\n",
     "```\n",
     "\n",
-    "`mk_msg` infers the type automatically and creates the appropriate data structure. \n",
-    "\n",
-    "`mk_msg` uses this more detailed data structure by default so the only change we need to make to our previous call is to drop the `text_only` flag. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ff355119",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'role': 'user', 'content': \"I'm Jeremy\"}"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "prompt = \"I'm Jeremy\"\n",
-    "m = mk_msg(prompt)\n",
-    "m"
+    "`mk_msg` infers the type automatically and creates the appropriate data structure. "
    ]
   },
   {
@@ -1903,9 +1897,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python3",
+   "display_name": "env",
    "language": "python",
-   "name": "python3"
+   "name": "env"
   }
  },
  "nbformat": 4,

--- a/cosette/core.py
+++ b/cosette/core.py
@@ -2,7 +2,8 @@
 
 # %% auto 0
 __all__ = ['empty', 'models', 'text_only_models', 'models_azure', 'find_block', 'contents', 'usage', 'wrap_latex', 'Client',
-           'get_stream', 'mk_openai_func', 'mk_tool_choice', 'call_func_openai', 'mk_toolres', 'mock_tooluse', 'Chat']
+           'get_stream', 'mk_openai_func', 'mk_tool_choice', 'call_func_openai', 'mk_toolres', 'mock_tooluse', 'Chat',
+           'mk_msg', 'mk_msgs']
 
 # %% ../00_core.ipynb 3
 from fastcore import imghdr
@@ -29,15 +30,18 @@ try: from IPython import display
 except: display=None
 
 # %% ../00_core.ipynb 5
+_all_ = ['mk_msg', 'mk_msgs']
+
+# %% ../00_core.ipynb 6
 empty = inspect.Parameter.empty
 
-# %% ../00_core.ipynb 7
+# %% ../00_core.ipynb 8
 models = 'o1-preview', 'o1-mini', 'gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo', 'gpt-4', 'gpt-4-32k', 'gpt-3.5-turbo', 'gpt-3.5-turbo-instruct'
 
-# %% ../00_core.ipynb 9
+# %% ../00_core.ipynb 10
 text_only_models = 'o1-preview', 'o1-mini'
 
-# %% ../00_core.ipynb 16
+# %% ../00_core.ipynb 17
 def find_block(r:abc.Mapping, # The message to look in
               ):
     "Find the message in `r`."
@@ -46,7 +50,7 @@ def find_block(r:abc.Mapping, # The message to look in
     if hasattr(m, 'message'): return m.message
     return m.delta
 
-# %% ../00_core.ipynb 17
+# %% ../00_core.ipynb 18
 def contents(r):
     "Helper to get the contents from response `r`."
     blk = find_block(r)
@@ -54,7 +58,7 @@ def contents(r):
     if hasattr(blk, 'content'): return getattr(blk,'content')
     return blk
 
-# %% ../00_core.ipynb 19
+# %% ../00_core.ipynb 20
 @patch
 def _repr_markdown_(self:ChatCompletion):
     det = '\n- '.join(f'{k}: {v}' for k,v in dict(self).items())
@@ -68,24 +72,24 @@ def _repr_markdown_(self:ChatCompletion):
 
 </details>"""
 
-# %% ../00_core.ipynb 22
+# %% ../00_core.ipynb 23
 def usage(inp=0, # Number of prompt tokens
           out=0  # Number of completion tokens
          ):
     "Slightly more concise version of `CompletionUsage`."
     return CompletionUsage(prompt_tokens=inp, completion_tokens=out, total_tokens=inp+out)
 
-# %% ../00_core.ipynb 24
+# %% ../00_core.ipynb 25
 @patch
 def __repr__(self:CompletionUsage): return f'In: {self.prompt_tokens}; Out: {self.completion_tokens}; Total: {self.total_tokens}'
 
-# %% ../00_core.ipynb 26
+# %% ../00_core.ipynb 27
 @patch
 def __add__(self:CompletionUsage, b):
     "Add together each of `input_tokens` and `output_tokens`"
     return usage(self.prompt_tokens+b.prompt_tokens, self.completion_tokens+b.completion_tokens)
 
-# %% ../00_core.ipynb 28
+# %% ../00_core.ipynb 29
 def wrap_latex(text, md=True):
     "Replace OpenAI LaTeX codes with markdown-compatible ones"
     text = re.sub(r"\\\((.*?)\\\)", lambda o: f"${o.group(1)}$", text)


### PR DESCRIPTION
This PR exports `mk_msg` and `mk_msgs`, which was overlooked when integrated `msglm` in #7.

This PR also makes some minor copy changes. 