### PR TITLE
enable o1 streaming

### DIFF
--- a/00_core.ipynb
+++ b/00_core.ipynb
@@ -185,7 +185,7 @@
    "outputs": [],
    "source": [
     "#| exports\n",
-    "has_streaming_models = set(models) - set(('o1', 'o1-mini', 'o3-mini'))\n",
+    "has_streaming_models = set(models) - set(('o1-mini', 'o3-mini'))\n",
     "has_system_prompt_models = set(models) - set(('o1-mini', 'o3-mini'))\n",
     "has_temperature_models = set(models) - set(('o1', 'o1-mini', 'o3-mini'))"
    ]

--- a/cosette/core.py
+++ b/cosette/core.py
@@ -43,7 +43,7 @@ models = 'o1-preview', 'o1-mini', 'gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo', 'gpt-4
 text_only_models = 'o1-preview', 'o1-mini', 'o3-mini'
 
 # %% ../00_core.ipynb 12
-has_streaming_models = set(models) - set(('o1', 'o1-mini', 'o3-mini'))
+has_streaming_models = set(models) - set(('o1-mini', 'o3-mini'))
 has_system_prompt_models = set(models) - set(('o1-mini', 'o3-mini'))
 has_temperature_models = set(models) - set(('o1', 'o1-mini', 'o3-mini'))
 


### PR DESCRIPTION
Just received an email from OAI:

```
Thank you for using OpenAI o1 in the API. Today, we’re adding one of o1’s most requested features—streaming—with support for both the Chat Completions API and Assistants API.
```