### PR TITLE
port `toolloop` and other updates from claudette and add new models

### DIFF
--- a/00_core.ipynb
+++ b/00_core.ipynb
@@ -103,27 +103,37 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Available models as of 2025-02-06:\n",
+      "Available models as of 2025-06-16:\n",
       "\n",
-      "babbage-002                   chatgpt-4o-latest             dall-e-2                      \n",
+      "babbage-002                   chatgpt-4o-latest             codex-mini-latest             \n",
+      "computer-use-preview          computer-use-preview-2025-03- dall-e-2                      \n",
       "dall-e-3                      davinci-002                   ft:gpt-4o-2024-08-06:answerai \n",
       "ft:gpt-4o-2024-08-06:answerai ft:gpt-4o-2024-08-06:answerai ft:gpt-4o-mini-2024-07-18:ans \n",
       "ft:gpt-4o-mini-2024-07-18:ans gpt-3.5-turbo                 gpt-3.5-turbo-0125            \n",
       "gpt-3.5-turbo-1106            gpt-3.5-turbo-16k             gpt-3.5-turbo-instruct        \n",
       "gpt-3.5-turbo-instruct-0914   gpt-4                         gpt-4-0125-preview            \n",
       "gpt-4-1106-preview            gpt-4-turbo                   gpt-4-turbo-2024-04-09        \n",
-      "gpt-4-turbo-preview           gpt-4o                        gpt-4o-2024-05-13             \n",
-      "gpt-4o-2024-08-06             gpt-4o-2024-11-20             gpt-4o-audio-preview          \n",
-      "gpt-4o-audio-preview-2024-10- gpt-4o-audio-preview-2024-12- gpt-4o-mini                   \n",
+      "gpt-4-turbo-preview           gpt-4.1                       gpt-4.1-2025-04-14            \n",
+      "gpt-4.1-mini                  gpt-4.1-mini-2025-04-14       gpt-4.1-nano                  \n",
+      "gpt-4.1-nano-2025-04-14       gpt-4.5-preview               gpt-4.5-preview-2025-02-27    \n",
+      "gpt-4o                        gpt-4o-2024-05-13             gpt-4o-2024-08-06             \n",
+      "gpt-4o-2024-11-20             gpt-4o-audio-preview          gpt-4o-audio-preview-2024-10- \n",
+      "gpt-4o-audio-preview-2024-12- gpt-4o-audio-preview-2025-06- gpt-4o-mini                   \n",
       "gpt-4o-mini-2024-07-18        gpt-4o-mini-audio-preview     gpt-4o-mini-audio-preview-202 \n",
-      "gpt-4o-mini-realtime-preview  gpt-4o-mini-realtime-preview- gpt-4o-realtime-preview       \n",
-      "gpt-4o-realtime-preview-2024- gpt-4o-realtime-preview-2024- o1                            \n",
+      "gpt-4o-mini-realtime-preview  gpt-4o-mini-realtime-preview- gpt-4o-mini-search-preview    \n",
+      "gpt-4o-mini-search-preview-20 gpt-4o-mini-transcribe        gpt-4o-mini-tts               \n",
+      "gpt-4o-realtime-preview       gpt-4o-realtime-preview-2024- gpt-4o-realtime-preview-2024- \n",
+      "gpt-4o-realtime-preview-2025- gpt-4o-search-preview         gpt-4o-search-preview-2025-03 \n",
+      "gpt-4o-transcribe             gpt-image-1                   o1                            \n",
       "o1-2024-12-17                 o1-mini                       o1-mini-2024-09-12            \n",
-      "o1-preview                    o1-preview-2024-09-12         o3-mini                       \n",
-      "o3-mini-2025-01-31            omni-moderation-2024-09-26    omni-moderation-latest        \n",
-      "text-embedding-3-large        text-embedding-3-small        text-embedding-ada-002        \n",
-      "tts-1                         tts-1-1106                    tts-1-hd                      \n",
-      "tts-1-hd-1106                 whisper-1                     \n"
+      "o1-preview                    o1-preview-2024-09-12         o1-pro                        \n",
+      "o1-pro-2025-03-19             o3                            o3-2025-04-16                 \n",
+      "o3-mini                       o3-mini-2025-01-31            o3-pro                        \n",
+      "o3-pro-2025-06-10             o4-mini                       o4-mini-2025-04-16            \n",
+      "omni-moderation-2024-09-26    omni-moderation-latest        text-embedding-3-large        \n",
+      "text-embedding-3-small        text-embedding-ada-002        tts-1                         \n",
+      "tts-1-1106                    tts-1-hd                      tts-1-hd-1106                 \n",
+      "whisper-1                     \n"
      ]
     }
    ],
@@ -155,7 +165,7 @@
    "outputs": [],
    "source": [
     "#| exports\n",
-    "models = 'o1-preview', 'o1-mini', 'gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo', 'gpt-4', 'gpt-4-32k', 'gpt-3.5-turbo', 'gpt-3.5-turbo-instruct', 'o1', 'o3-mini', 'chatgpt-4o-latest'"
+    "models = 'o1-preview', 'o1-mini', 'gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo', 'gpt-4', 'gpt-4-32k', 'gpt-3.5-turbo', 'gpt-3.5-turbo-instruct', 'o1', 'o3-mini', 'chatgpt-4o-latest', 'o1-pro', 'o3', 'o4-mini'"
    ]
   },
   {
@@ -272,23 +282,23 @@
     {
      "data": {
       "text/markdown": [
-       "Hello, Jeremy! How can I assist you today?\n",
+       "Hi Jeremy! How can I assist you today?\n",
        "\n",
        "<details>\n",
        "\n",
-       "- id: chatcmpl-AxxDzLirSVOpB1Fa5YINYyvmVNJtj\n",
-       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Hello, Jeremy! How can I assist you today?', refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None))]\n",
-       "- created: 1738852375\n",
+       "- id: chatcmpl-Bj85MawCF7lcLn3xXDvMCOvIMqrMS\n",
+       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Hi Jeremy! How can I assist you today?', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))]\n",
+       "- created: 1750095540\n",
        "- model: gpt-4o-2024-08-06\n",
        "- object: chat.completion\n",
        "- service_tier: default\n",
-       "- system_fingerprint: fp_50cad350e4\n",
-       "- usage: CompletionUsage(completion_tokens=12, prompt_tokens=9, total_tokens=21, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
+       "- system_fingerprint: fp_a288987b44\n",
+       "- usage: CompletionUsage(completion_tokens=10, prompt_tokens=9, total_tokens=19, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "ChatCompletion(id='chatcmpl-AxxDzLirSVOpB1Fa5YINYyvmVNJtj', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Hello, Jeremy! How can I assist you today?', refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None))], created=1738852375, model='gpt-4o-2024-08-06', object='chat.completion', service_tier='default', system_fingerprint='fp_50cad350e4', usage=In: 9; Out: 12; Total: 21)"
+       "ChatCompletion(id='chatcmpl-Bj85MawCF7lcLn3xXDvMCOvIMqrMS', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Hi Jeremy! How can I assist you today?', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))], created=1750095540, model='gpt-4o-2024-08-06', object='chat.completion', service_tier='default', system_fingerprint='fp_a288987b44', usage=In: 9; Out: 10; Total: 19)"
       ]
      },
      "execution_count": null,
@@ -352,7 +362,7 @@
     {
      "data": {
       "text/plain": [
-       "'Hello, Jeremy! How can I assist you today?'"
+       "'Hi Jeremy! How can I assist you today?'"
       ]
      },
      "execution_count": null,
@@ -395,23 +405,23 @@
     {
      "data": {
       "text/markdown": [
-       "Hello, Jeremy! How can I assist you today?\n",
+       "Hi Jeremy! How can I assist you today?\n",
        "\n",
        "<details>\n",
        "\n",
-       "- id: chatcmpl-AxxDzLirSVOpB1Fa5YINYyvmVNJtj\n",
-       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Hello, Jeremy! How can I assist you today?', refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None))]\n",
-       "- created: 1738852375\n",
+       "- id: chatcmpl-Bj85MawCF7lcLn3xXDvMCOvIMqrMS\n",
+       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Hi Jeremy! How can I assist you today?', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))]\n",
+       "- created: 1750095540\n",
        "- model: gpt-4o-2024-08-06\n",
        "- object: chat.completion\n",
        "- service_tier: default\n",
-       "- system_fingerprint: fp_50cad350e4\n",
-       "- usage: CompletionUsage(completion_tokens=12, prompt_tokens=9, total_tokens=21, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
+       "- system_fingerprint: fp_a288987b44\n",
+       "- usage: CompletionUsage(completion_tokens=10, prompt_tokens=9, total_tokens=19, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "ChatCompletion(id='chatcmpl-AxxDzLirSVOpB1Fa5YINYyvmVNJtj', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Hello, Jeremy! How can I assist you today?', refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None))], created=1738852375, model='gpt-4o-2024-08-06', object='chat.completion', service_tier='default', system_fingerprint='fp_50cad350e4', usage=In: 9; Out: 12; Total: 21)"
+       "ChatCompletion(id='chatcmpl-Bj85MawCF7lcLn3xXDvMCOvIMqrMS', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Hi Jeremy! How can I assist you today?', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))], created=1750095540, model='gpt-4o-2024-08-06', object='chat.completion', service_tier='default', system_fingerprint='fp_a288987b44', usage=In: 9; Out: 10; Total: 19)"
       ]
      },
      "execution_count": null,
@@ -432,7 +442,7 @@
     {
      "data": {
       "text/plain": [
-       "In: 9; Out: 12; Total: 21"
+       "In: 9; Out: 10; Total: 19"
       ]
      },
      "execution_count": null,
@@ -501,7 +511,7 @@
     {
      "data": {
       "text/plain": [
-       "In: 9; Out: 12; Total: 21"
+       "In: 9; Out: 10; Total: 19"
       ]
      },
      "execution_count": null,
@@ -536,7 +546,7 @@
     {
      "data": {
       "text/plain": [
-       "In: 18; Out: 24; Total: 42"
+       "In: 18; Out: 20; Total: 38"
       ]
      },
      "execution_count": null,
@@ -595,19 +605,19 @@
        "\n",
        "<details>\n",
        "\n",
-       "- id: chatcmpl-AxxE1Vtsvd9GeFEY8Db18sZLLZBQc\n",
-       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Hello, Jeremy! How can I assist you today?', refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None))]\n",
-       "- created: 1738852377\n",
+       "- id: chatcmpl-Bj85VJLfu06opFd9yX4brDsvgKhjP\n",
+       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Hello, Jeremy! How can I assist you today?', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))]\n",
+       "- created: 1750095549\n",
        "- model: gpt-4o-2024-08-06\n",
        "- object: chat.completion\n",
        "- service_tier: default\n",
-       "- system_fingerprint: fp_4691090a87\n",
-       "- usage: CompletionUsage(completion_tokens=12, prompt_tokens=9, total_tokens=21, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
+       "- system_fingerprint: fp_07871e2ad8\n",
+       "- usage: CompletionUsage(completion_tokens=11, prompt_tokens=9, total_tokens=20, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "ChatCompletion(id='chatcmpl-AxxE1Vtsvd9GeFEY8Db18sZLLZBQc', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Hello, Jeremy! How can I assist you today?', refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None))], created=1738852377, model='gpt-4o-2024-08-06', object='chat.completion', service_tier='default', system_fingerprint='fp_4691090a87', usage=In: 9; Out: 12; Total: 21)"
+       "ChatCompletion(id='chatcmpl-Bj85VJLfu06opFd9yX4brDsvgKhjP', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Hello, Jeremy! How can I assist you today?', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))], created=1750095549, model='gpt-4o-2024-08-06', object='chat.completion', service_tier='default', system_fingerprint='fp_07871e2ad8', usage=In: 9; Out: 11; Total: 20)"
       ]
      },
      "execution_count": null,
@@ -662,7 +672,7 @@
      "data": {
       "text/plain": [
        "[{'role': 'user', 'content': \"I'm Jeremy\"},\n",
-       " ChatCompletionMessage(content='Hello, Jeremy! How can I assist you today?', refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None),\n",
+       " ChatCompletionMessage(content='Hello, Jeremy! How can I assist you today?', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None),\n",
        " {'role': 'user', 'content': 'I forgot my name. Can you remind me please?'}]"
       ]
      },
@@ -685,23 +695,23 @@
     {
      "data": {
       "text/markdown": [
-       "It sounds like you're having a bit of a memory lapse! You just mentioned that your name is Jeremy. If there's anything else you need help with, feel free to ask.\n",
+       "It sounds like you might be joking, but if you're serious and experiencing memory issues, it's important to reach out to a healthcare professional for assistance. If there's anything else you'd like to talk about or need help with, feel free to let me know!\n",
        "\n",
        "<details>\n",
        "\n",
-       "- id: chatcmpl-AxxE28BxbRMXrKAMxiNw0dHXT9h6r\n",
-       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content=\"It sounds like you're having a bit of a memory lapse! You just mentioned that your name is Jeremy. If there's anything else you need help with, feel free to ask.\", refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None))]\n",
-       "- created: 1738852378\n",
+       "- id: chatcmpl-Bj85Zl24Oj7BgVqh7svflZfMeIl4A\n",
+       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content=\"It sounds like you might be joking, but if you're serious and experiencing memory issues, it's important to reach out to a healthcare professional for assistance. If there's anything else you'd like to talk about or need help with, feel free to let me know!\", refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))]\n",
+       "- created: 1750095553\n",
        "- model: gpt-4o-2024-08-06\n",
        "- object: chat.completion\n",
        "- service_tier: default\n",
-       "- system_fingerprint: fp_4691090a87\n",
-       "- usage: CompletionUsage(completion_tokens=36, prompt_tokens=39, total_tokens=75, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
+       "- system_fingerprint: fp_07871e2ad8\n",
+       "- usage: CompletionUsage(completion_tokens=50, prompt_tokens=39, total_tokens=89, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "ChatCompletion(id='chatcmpl-AxxE28BxbRMXrKAMxiNw0dHXT9h6r', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content=\"It sounds like you're having a bit of a memory lapse! You just mentioned that your name is Jeremy. If there's anything else you need help with, feel free to ask.\", refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None))], created=1738852378, model='gpt-4o-2024-08-06', object='chat.completion', service_tier='default', system_fingerprint='fp_4691090a87', usage=In: 39; Out: 36; Total: 75)"
+       "ChatCompletion(id='chatcmpl-Bj85Zl24Oj7BgVqh7svflZfMeIl4A', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content=\"It sounds like you might be joking, but if you're serious and experiencing memory issues, it's important to reach out to a healthcare professional for assistance. If there's anything else you'd like to talk about or need help with, feel free to let me know!\", refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))], created=1750095553, model='gpt-4o-2024-08-06', object='chat.completion', service_tier='default', system_fingerprint='fp_07871e2ad8', usage=In: 39; Out: 50; Total: 89)"
       ]
      },
      "execution_count": null,
@@ -784,7 +794,7 @@
     {
      "data": {
       "text/plain": [
-       "In: 9; Out: 12; Total: 21"
+       "In: 9; Out: 11; Total: 20"
       ]
      },
      "execution_count": null,
@@ -863,19 +873,19 @@
        "\n",
        "<details>\n",
        "\n",
-       "- id: chatcmpl-AxxE4eN6uGVZpCt4DqZpeqAfeVcVF\n",
-       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Hello! How can I assist you today?', refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None))]\n",
-       "- created: 1738852380\n",
+       "- id: chatcmpl-Bj85cFcpizu1XXiesoFUXmnsfyCrh\n",
+       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Hello! How can I assist you today?', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))]\n",
+       "- created: 1750095556\n",
        "- model: gpt-4o-2024-08-06\n",
        "- object: chat.completion\n",
        "- service_tier: default\n",
-       "- system_fingerprint: fp_4691090a87\n",
-       "- usage: CompletionUsage(completion_tokens=10, prompt_tokens=8, total_tokens=18, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
+       "- system_fingerprint: fp_a288987b44\n",
+       "- usage: CompletionUsage(completion_tokens=9, prompt_tokens=8, total_tokens=17, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "ChatCompletion(id='chatcmpl-AxxE4eN6uGVZpCt4DqZpeqAfeVcVF', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Hello! How can I assist you today?', refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None))], created=1738852380, model='gpt-4o-2024-08-06', object='chat.completion', service_tier='default', system_fingerprint='fp_4691090a87', usage=In: 8; Out: 10; Total: 18)"
+       "ChatCompletion(id='chatcmpl-Bj85cFcpizu1XXiesoFUXmnsfyCrh', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Hello! How can I assist you today?', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))], created=1750095556, model='gpt-4o-2024-08-06', object='chat.completion', service_tier='default', system_fingerprint='fp_a288987b44', usage=In: 8; Out: 9; Total: 17)"
       ]
      },
      "execution_count": null,
@@ -896,7 +906,7 @@
     {
      "data": {
       "text/plain": [
-       "In: 17; Out: 22; Total: 39"
+       "In: 17; Out: 20; Total: 37"
       ]
      },
      "execution_count": null,
@@ -935,7 +945,7 @@
     {
      "data": {
       "text/plain": [
-       "In: 25; Out: 32; Total: 57"
+       "In: 25; Out: 29; Total: 54"
       ]
      },
      "execution_count": null,
@@ -1028,17 +1038,17 @@
     {
      "data": {
       "text/markdown": [
-       "- id: chatcmpl-AxxE60yQrAQborSaxvspHxWKbI1We\n",
-       "- choices: [Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, refusal=None, role='assistant', audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_gxbDrZ9AmIuSgvgQSoUCCp2N', function=Function(arguments='{\"a\":604542,\"b\":6458932}', name='sums'), type='function')]))]\n",
-       "- created: 1738852382\n",
+       "- id: chatcmpl-Bj85etFYQhLGtEJWVYs48VZPjQzbv\n",
+       "- choices: [Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_V0SpNsfT1LBvDlBSlT4pe44Q', function=Function(arguments='{\"a\":604542,\"b\":6458932}', name='sums'), type='function')]))]\n",
+       "- created: 1750095558\n",
        "- model: gpt-4o-2024-08-06\n",
        "- object: chat.completion\n",
        "- service_tier: default\n",
-       "- system_fingerprint: fp_50cad350e4\n",
-       "- usage: CompletionUsage(completion_tokens=22, prompt_tokens=94, total_tokens=116, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))"
+       "- system_fingerprint: fp_07871e2ad8\n",
+       "- usage: CompletionUsage(completion_tokens=21, prompt_tokens=94, total_tokens=115, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))"
       ],
       "text/plain": [
-       "ChatCompletion(id='chatcmpl-AxxE60yQrAQborSaxvspHxWKbI1We', choices=[Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, refusal=None, role='assistant', audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_gxbDrZ9AmIuSgvgQSoUCCp2N', function=Function(arguments='{\"a\":604542,\"b\":6458932}', name='sums'), type='function')]))], created=1738852382, model='gpt-4o-2024-08-06', object='chat.completion', service_tier='default', system_fingerprint='fp_50cad350e4', usage=In: 94; Out: 22; Total: 116)"
+       "ChatCompletion(id='chatcmpl-Bj85etFYQhLGtEJWVYs48VZPjQzbv', choices=[Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_V0SpNsfT1LBvDlBSlT4pe44Q', function=Function(arguments='{\"a\":604542,\"b\":6458932}', name='sums'), type='function')]))], created=1750095558, model='gpt-4o-2024-08-06', object='chat.completion', service_tier='default', system_fingerprint='fp_07871e2ad8', usage=In: 94; Out: 21; Total: 115)"
       ]
      },
      "execution_count": null,
@@ -1061,7 +1071,7 @@
     {
      "data": {
       "text/plain": [
-       "ChatCompletionMessage(content=None, refusal=None, role='assistant', audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_gxbDrZ9AmIuSgvgQSoUCCp2N', function=Function(arguments='{\"a\":604542,\"b\":6458932}', name='sums'), type='function')])"
+       "ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_V0SpNsfT1LBvDlBSlT4pe44Q', function=Function(arguments='{\"a\":604542,\"b\":6458932}', name='sums'), type='function')])"
       ]
      },
      "execution_count": null,
@@ -1083,7 +1093,7 @@
     {
      "data": {
       "text/plain": [
-       "[ChatCompletionMessageToolCall(id='call_gxbDrZ9AmIuSgvgQSoUCCp2N', function=Function(arguments='{\"a\":604542,\"b\":6458932}', name='sums'), type='function')]"
+       "[ChatCompletionMessageToolCall(id='call_V0SpNsfT1LBvDlBSlT4pe44Q', function=Function(arguments='{\"a\":604542,\"b\":6458932}', name='sums'), type='function')]"
       ]
      },
      "execution_count": null,
@@ -1127,7 +1137,7 @@
    "source": [
     "#| exports\n",
     "def call_func_openai(func:types.chat.chat_completion_message_tool_call.Function, ns:Optional[abc.Mapping]=None):\n",
-    "    return call_func(func.name, ast.literal_eval(func.arguments), ns)"
+    "    return call_func(func.name, ast.literal_eval(func.arguments), ns, raise_on_err=False)"
    ]
   },
   {
@@ -1202,10 +1212,10 @@
     {
      "data": {
       "text/plain": [
-       "[ChatCompletionMessage(content=None, refusal=None, role='assistant', audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_gxbDrZ9AmIuSgvgQSoUCCp2N', function=Function(arguments='{\"a\":604542,\"b\":6458932}', name='sums'), type='function')]),\n",
+       "[ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_V0SpNsfT1LBvDlBSlT4pe44Q', function=Function(arguments='{\"a\":604542,\"b\":6458932}', name='sums'), type='function')]),\n",
        " {'role': 'tool',\n",
        "  'content': '7063474',\n",
-       "  'tool_call_id': 'call_gxbDrZ9AmIuSgvgQSoUCCp2N',\n",
+       "  'tool_call_id': 'call_V0SpNsfT1LBvDlBSlT4pe44Q',\n",
        "  'name': 'sums'}]"
       ]
      },
@@ -1238,23 +1248,23 @@
     {
      "data": {
       "text/markdown": [
-       "The sum of 604542 and 6458932 is 7,063,474.\n",
+       "The sum of 604542 and 6458932 is 7063474.\n",
        "\n",
        "<details>\n",
        "\n",
-       "- id: chatcmpl-AxxE77DTrlhWfU5FKcM2ZYwqhggUI\n",
-       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The sum of 604542 and 6458932 is 7,063,474.', refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None))]\n",
-       "- created: 1738852383\n",
+       "- id: chatcmpl-Bj85gwF8jmYgkWB3ipnu8NBdAogKm\n",
+       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The sum of 604542 and 6458932 is 7063474.', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))]\n",
+       "- created: 1750095560\n",
        "- model: gpt-4o-2024-08-06\n",
        "- object: chat.completion\n",
        "- service_tier: default\n",
-       "- system_fingerprint: fp_4691090a87\n",
-       "- usage: CompletionUsage(completion_tokens=21, prompt_tokens=126, total_tokens=147, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
+       "- system_fingerprint: fp_07871e2ad8\n",
+       "- usage: CompletionUsage(completion_tokens=18, prompt_tokens=126, total_tokens=144, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "ChatCompletion(id='chatcmpl-AxxE77DTrlhWfU5FKcM2ZYwqhggUI', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The sum of 604542 and 6458932 is 7,063,474.', refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None))], created=1738852383, model='gpt-4o-2024-08-06', object='chat.completion', service_tier='default', system_fingerprint='fp_4691090a87', usage=In: 126; Out: 21; Total: 147)"
+       "ChatCompletion(id='chatcmpl-Bj85gwF8jmYgkWB3ipnu8NBdAogKm', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The sum of 604542 and 6458932 is 7063474.', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))], created=1750095560, model='gpt-4o-2024-08-06', object='chat.completion', service_tier='default', system_fingerprint='fp_07871e2ad8', usage=In: 126; Out: 18; Total: 144)"
       ]
      },
      "execution_count": null,
@@ -1294,23 +1304,23 @@
     {
      "data": {
       "text/markdown": [
-       "Hello Jeremy! What can I do for you today?\n",
+       "How can I assist you today, Jeremy?\n",
        "\n",
        "<details>\n",
        "\n",
-       "- id: chatcmpl-AxxEB3zopAfdLdTDAKxMN7U3JYoha\n",
-       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Hello Jeremy! What can I do for you today?', refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None))]\n",
-       "- created: 1738852387\n",
+       "- id: chatcmpl-Bj85iW4ZNqOYTiBqkyb7kABJtY58V\n",
+       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='How can I assist you today, Jeremy?', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))]\n",
+       "- created: 1750095562\n",
        "- model: gpt-4o-2024-08-06\n",
        "- object: chat.completion\n",
        "- service_tier: default\n",
-       "- system_fingerprint: fp_4691090a87\n",
-       "- usage: CompletionUsage(completion_tokens=13, prompt_tokens=106, total_tokens=119, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
+       "- system_fingerprint: fp_a288987b44\n",
+       "- usage: CompletionUsage(completion_tokens=10, prompt_tokens=107, total_tokens=117, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "ChatCompletion(id='chatcmpl-AxxEB3zopAfdLdTDAKxMN7U3JYoha', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Hello Jeremy! What can I do for you today?', refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None))], created=1738852387, model='gpt-4o-2024-08-06', object='chat.completion', service_tier='default', system_fingerprint='fp_4691090a87', usage=In: 106; Out: 13; Total: 119)"
+       "ChatCompletion(id='chatcmpl-Bj85iW4ZNqOYTiBqkyb7kABJtY58V', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='How can I assist you today, Jeremy?', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))], created=1750095562, model='gpt-4o-2024-08-06', object='chat.completion', service_tier='default', system_fingerprint='fp_a288987b44', usage=In: 107; Out: 10; Total: 117)"
       ]
      },
      "execution_count": null,
@@ -1339,7 +1349,7 @@
      "data": {
       "text/plain": [
        "[{'role': 'user', 'content': \"I'm Jeremy\"},\n",
-       " ChatCompletionMessage(content='Hi Jeremy! How can I assist you today?', refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None)]"
+       " ChatCompletionMessage(content='Hello, Jeremy! How can I assist you today?', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None)]"
       ]
      },
      "execution_count": null,
@@ -1367,23 +1377,23 @@
     {
      "data": {
       "text/markdown": [
-       "The result of \\( 604542 + 6458932 \\) is 7,063,474.\n",
+       "The sum of 604542 and 6458932 is 7063474.\n",
        "\n",
        "<details>\n",
        "\n",
-       "- id: chatcmpl-AxxEDgQUhxjSyQp9iaRmyVmAadi5q\n",
-       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The result of \\\\( 604542 + 6458932 \\\\) is 7,063,474.', refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None))]\n",
-       "- created: 1738852389\n",
+       "- id: chatcmpl-Bj85kVUcdXnzStbRiQU5AFiAzOLEh\n",
+       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The sum of 604542 and 6458932 is 7063474.', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))]\n",
+       "- created: 1750095564\n",
        "- model: gpt-4o-2024-08-06\n",
        "- object: chat.completion\n",
        "- service_tier: default\n",
-       "- system_fingerprint: fp_50cad350e4\n",
-       "- usage: CompletionUsage(completion_tokens=24, prompt_tokens=132, total_tokens=156, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
+       "- system_fingerprint: fp_a288987b44\n",
+       "- usage: CompletionUsage(completion_tokens=18, prompt_tokens=132, total_tokens=150, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "ChatCompletion(id='chatcmpl-AxxEDgQUhxjSyQp9iaRmyVmAadi5q', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The result of \\\\( 604542 + 6458932 \\\\) is 7,063,474.', refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None))], created=1738852389, model='gpt-4o-2024-08-06', object='chat.completion', service_tier='default', system_fingerprint='fp_50cad350e4', usage=In: 132; Out: 24; Total: 156)"
+       "ChatCompletion(id='chatcmpl-Bj85kVUcdXnzStbRiQU5AFiAzOLEh', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The sum of 604542 and 6458932 is 7063474.', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))], created=1750095564, model='gpt-4o-2024-08-06', object='chat.completion', service_tier='default', system_fingerprint='fp_a288987b44', usage=In: 132; Out: 18; Total: 150)"
       ]
      },
      "execution_count": null,
@@ -1442,23 +1452,23 @@
     {
      "data": {
       "text/markdown": [
-       "The sum of 604542 and 6458932 is 7063474.\n",
+       "The sum of 604542 and 6458932 is 7,063,474.\n",
        "\n",
        "<details>\n",
        "\n",
-       "- id: chatcmpl-AxxEEgwmhB6rTQiEHNbmN6HdLGFDg\n",
-       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The sum of 604542 and 6458932 is 7063474.', refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None))]\n",
-       "- created: 1738852390\n",
+       "- id: chatcmpl-Bj85lyiy7vlWFOAtaiCDG3faBNaGw\n",
+       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The sum of 604542 and 6458932 is 7,063,474.', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))]\n",
+       "- created: 1750095565\n",
        "- model: gpt-4o-2024-08-06\n",
        "- object: chat.completion\n",
        "- service_tier: default\n",
-       "- system_fingerprint: fp_7b6a074e04\n",
-       "- usage: CompletionUsage(completion_tokens=19, prompt_tokens=111, total_tokens=130, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
+       "- system_fingerprint: fp_07871e2ad8\n",
+       "- usage: CompletionUsage(completion_tokens=20, prompt_tokens=111, total_tokens=131, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "ChatCompletion(id='chatcmpl-AxxEEgwmhB6rTQiEHNbmN6HdLGFDg', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The sum of 604542 and 6458932 is 7063474.', refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None))], created=1738852390, model='gpt-4o-2024-08-06', object='chat.completion', service_tier='default', system_fingerprint='fp_7b6a074e04', usage=In: 111; Out: 19; Total: 130)"
+       "ChatCompletion(id='chatcmpl-Bj85lyiy7vlWFOAtaiCDG3faBNaGw', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The sum of 604542 and 6458932 is 7,063,474.', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))], created=1750095565, model='gpt-4o-2024-08-06', object='chat.completion', service_tier='default', system_fingerprint='fp_07871e2ad8', usage=In: 111; Out: 20; Total: 131)"
       ]
      },
      "execution_count": null,
@@ -1569,7 +1579,7 @@
     "        \"OpenAI chat client.\"\n",
     "        assert model or cli\n",
     "        self.c = (cli or Client(model))\n",
-    "        self.h,self.sp,self.tools,self.tool_choice = [],sp,tools,tool_choice\n",
+    "        self.h,self.sp,self.tools,self.tool_choice = [],sp,listify(tools),tool_choice\n",
     "    \n",
     "    @property\n",
     "    def use(self): return self.c.use"
@@ -1618,7 +1628,8 @@
     "    if self.tools: kwargs['tools'] = [mk_openai_func(o) for o in self.tools]\n",
     "    if self.tool_choice: kwargs['tool_choice'] = mk_tool_choice(self.tool_choice)\n",
     "    res = self.c(self.h, sp=self.sp, stream=stream, **kwargs)\n",
-    "    self.h += mk_toolres(res, ns=self.tools)\n",
+    "    self.last = mk_toolres(res, ns=self.tools)\n",
+    "    self.h += self.last\n",
     "    return res"
    ]
   },
@@ -1631,23 +1642,23 @@
     {
      "data": {
       "text/markdown": [
-       "Your name is Jeremy. How can I help you today?\n",
+       "You mentioned that your name is Jeremy. How can I help you today?\n",
        "\n",
        "<details>\n",
        "\n",
-       "- id: chatcmpl-AxxEGWAHp292zs25lAzsUAW68RaQm\n",
-       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Your name is Jeremy. How can I help you today?', refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None))]\n",
-       "- created: 1738852392\n",
+       "- id: chatcmpl-Bj85ugSdOE0bTe7LMAxVotaGoUAFs\n",
+       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='You mentioned that your name is Jeremy. How can I help you today?', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))]\n",
+       "- created: 1750095574\n",
        "- model: gpt-4o-2024-08-06\n",
        "- object: chat.completion\n",
        "- service_tier: default\n",
-       "- system_fingerprint: fp_4691090a87\n",
-       "- usage: CompletionUsage(completion_tokens=13, prompt_tokens=43, total_tokens=56, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
+       "- system_fingerprint: fp_a288987b44\n",
+       "- usage: CompletionUsage(completion_tokens=15, prompt_tokens=43, total_tokens=58, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "ChatCompletion(id='chatcmpl-AxxEGWAHp292zs25lAzsUAW68RaQm', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Your name is Jeremy. How can I help you today?', refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None))], created=1738852392, model='gpt-4o-2024-08-06', object='chat.completion', service_tier='default', system_fingerprint='fp_4691090a87', usage=In: 43; Out: 13; Total: 56)"
+       "ChatCompletion(id='chatcmpl-Bj85ugSdOE0bTe7LMAxVotaGoUAFs', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='You mentioned that your name is Jeremy. How can I help you today?', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))], created=1750095574, model='gpt-4o-2024-08-06', object='chat.completion', service_tier='default', system_fingerprint='fp_a288987b44', usage=In: 43; Out: 15; Total: 58)"
       ]
      },
      "execution_count": null,
@@ -1670,7 +1681,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Hi Jeremy! How can I assist you today?"
+      "Hello, Jeremy! How can I assist you today?"
      ]
     }
    ],
@@ -1703,10 +1714,10 @@
       "1233 * 4297 = 5298201\n",
       "\n",
       "gpt-4o Answer:\n",
-      "1233 multiplied by 4297 is 5,295,201.\n",
+      "The product of 1233 and 4297 is 5,295,201.\n",
       "\n",
       "o-1 Answer:\n",
-      "1233 × 4297 = 5,298,201.\n"
+      "The product of 1233 and 4297 is 5,298,201.\n"
      ]
     }
    ],
@@ -1771,17 +1782,17 @@
     {
      "data": {
       "text/markdown": [
-       "- id: chatcmpl-AxxENmOGgDLJf76uw6zAa04gp3ttA\n",
-       "- choices: [Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, refusal=None, role='assistant', audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_H906YFMeZg2yDdiWKoBbtvw6', function=Function(arguments='{\"a\":604542,\"b\":6458932}', name='sums'), type='function')]))]\n",
-       "- created: 1738852399\n",
+       "- id: chatcmpl-Bj87R0nMfOEItcKu0tAO98xUS0Id8\n",
+       "- choices: [Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_hudjmlgJB4JggkzoIYrSJPdA', function=Function(arguments='{\"a\":604542,\"b\":6458932}', name='sums'), type='function')]))]\n",
+       "- created: 1750095669\n",
        "- model: gpt-4o-2024-08-06\n",
        "- object: chat.completion\n",
        "- service_tier: default\n",
-       "- system_fingerprint: fp_4691090a87\n",
-       "- usage: CompletionUsage(completion_tokens=22, prompt_tokens=80, total_tokens=102, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))"
+       "- system_fingerprint: fp_a288987b44\n",
+       "- usage: CompletionUsage(completion_tokens=21, prompt_tokens=80, total_tokens=101, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))"
       ],
       "text/plain": [
-       "ChatCompletion(id='chatcmpl-AxxENmOGgDLJf76uw6zAa04gp3ttA', choices=[Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, refusal=None, role='assistant', audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_H906YFMeZg2yDdiWKoBbtvw6', function=Function(arguments='{\"a\":604542,\"b\":6458932}', name='sums'), type='function')]))], created=1738852399, model='gpt-4o-2024-08-06', object='chat.completion', service_tier='default', system_fingerprint='fp_4691090a87', usage=In: 80; Out: 22; Total: 102)"
+       "ChatCompletion(id='chatcmpl-Bj87R0nMfOEItcKu0tAO98xUS0Id8', choices=[Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_hudjmlgJB4JggkzoIYrSJPdA', function=Function(arguments='{\"a\":604542,\"b\":6458932}', name='sums'), type='function')]))], created=1750095669, model='gpt-4o-2024-08-06', object='chat.completion', service_tier='default', system_fingerprint='fp_a288987b44', usage=In: 80; Out: 21; Total: 101)"
       ]
      },
      "execution_count": null,
@@ -1808,19 +1819,19 @@
        "\n",
        "<details>\n",
        "\n",
-       "- id: chatcmpl-AxxEOmWmCSUxAVslLnDwNIA1Qlpcx\n",
-       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The sum of 604542 and 6458932 is 7063474.', refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None))]\n",
-       "- created: 1738852400\n",
+       "- id: chatcmpl-Bj87SpoNYPG0A3Z4Sku2SNGDjPdJY\n",
+       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The sum of 604542 and 6458932 is 7063474.', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))]\n",
+       "- created: 1750095670\n",
        "- model: gpt-4o-2024-08-06\n",
        "- object: chat.completion\n",
        "- service_tier: default\n",
-       "- system_fingerprint: fp_4691090a87\n",
-       "- usage: CompletionUsage(completion_tokens=19, prompt_tokens=112, total_tokens=131, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
+       "- system_fingerprint: fp_a288987b44\n",
+       "- usage: CompletionUsage(completion_tokens=18, prompt_tokens=112, total_tokens=130, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "ChatCompletion(id='chatcmpl-AxxEOmWmCSUxAVslLnDwNIA1Qlpcx', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The sum of 604542 and 6458932 is 7063474.', refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None))], created=1738852400, model='gpt-4o-2024-08-06', object='chat.completion', service_tier='default', system_fingerprint='fp_4691090a87', usage=In: 112; Out: 19; Total: 131)"
+       "ChatCompletion(id='chatcmpl-Bj87SpoNYPG0A3Z4Sku2SNGDjPdJY', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The sum of 604542 and 6458932 is 7063474.', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))], created=1750095670, model='gpt-4o-2024-08-06', object='chat.completion', service_tier='default', system_fingerprint='fp_a288987b44', usage=In: 112; Out: 18; Total: 130)"
       ]
      },
      "execution_count": null,
@@ -1931,19 +1942,19 @@
        "\n",
        "<details>\n",
        "\n",
-       "- id: chatcmpl-AxxEQLbPnVVEmTjyVmmU5TWTIddeW\n",
-       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The flowers in the image are purple.', refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None))]\n",
-       "- created: 1738852402\n",
+       "- id: chatcmpl-Bj8KK7vsnX8RiF65fCWUKSIBWJQAP\n",
+       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The flowers in the image are purple.', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))]\n",
+       "- created: 1750096468\n",
        "- model: gpt-4o-2024-08-06\n",
        "- object: chat.completion\n",
        "- service_tier: default\n",
-       "- system_fingerprint: fp_4691090a87\n",
-       "- usage: CompletionUsage(completion_tokens=9, prompt_tokens=458, total_tokens=467, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
+       "- system_fingerprint: fp_a288987b44\n",
+       "- usage: CompletionUsage(completion_tokens=8, prompt_tokens=273, total_tokens=281, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "ChatCompletion(id='chatcmpl-AxxEQLbPnVVEmTjyVmmU5TWTIddeW', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The flowers in the image are purple.', refusal=None, role='assistant', audio=None, function_call=None, tool_calls=None))], created=1738852402, model='gpt-4o-2024-08-06', object='chat.completion', service_tier='default', system_fingerprint='fp_4691090a87', usage=In: 458; Out: 9; Total: 467)"
+       "ChatCompletion(id='chatcmpl-Bj8KK7vsnX8RiF65fCWUKSIBWJQAP', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The flowers in the image are purple.', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))], created=1750096468, model='gpt-4o-2024-08-06', object='chat.completion', service_tier='default', system_fingerprint='fp_a288987b44', usage=In: 273; Out: 8; Total: 281)"
       ]
      },
      "execution_count": null,

--- a/01_toolloop.ipynb
+++ b/01_toolloop.ipynb
@@ -36,11 +36,99 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f998b27f",
+   "id": "b7951c8f",
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = models[0]"
+    "from IPython.display import display, Markdown, clear_output\n",
+    "from pprint import pprint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "596a22f4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('o1-preview',\n",
+       " 'o1-mini',\n",
+       " 'gpt-4o',\n",
+       " 'gpt-4o-mini',\n",
+       " 'gpt-4-turbo',\n",
+       " 'gpt-4',\n",
+       " 'gpt-4-32k',\n",
+       " 'gpt-3.5-turbo',\n",
+       " 'gpt-3.5-turbo-instruct',\n",
+       " 'o1',\n",
+       " 'o3-mini',\n",
+       " 'chatgpt-4o-latest',\n",
+       " 'o1-pro',\n",
+       " 'o3',\n",
+       " 'o4-mini')"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f998b27f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'o4-mini'"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model = models[14]\n",
+    "model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a49b64b5",
+   "metadata": {},
+   "source": [
+    "## Sample Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34342c4b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def _get_orders_customers():\n",
+    "    orders = {\n",
+    "        \"O1\": dict(id=\"O1\", product=\"Widget A\", quantity=2, price=19.99, status=\"Shipped\"),\n",
+    "        \"O2\": dict(id=\"O2\", product=\"Gadget B\", quantity=1, price=49.99, status=\"Processing\"),\n",
+    "        \"O3\": dict(id=\"O3\", product=\"Gadget B\", quantity=2, price=49.99, status=\"Shipped\")}\n",
+    "\n",
+    "    customers = {\n",
+    "        \"C1\": dict(name=\"John Doe\", email=\"john@example.com\", phone=\"123-456-7890\",\n",
+    "                   orders=[orders['O1'], orders['O2']]),\n",
+    "        \"C2\": dict(name=\"Jane Smith\", email=\"jane@example.com\", phone=\"987-654-3210\",\n",
+    "                   orders=[orders['O3']])\n",
+    "    }\n",
+    "    return orders, customers"
    ]
   },
   {
@@ -50,17 +138,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "orders = {\n",
-    "    \"O1\": dict(id=\"O1\", product=\"Widget A\", quantity=2, price=19.99, status=\"Shipped\"),\n",
-    "    \"O2\": dict(id=\"O2\", product=\"Gadget B\", quantity=1, price=49.99, status=\"Processing\"),\n",
-    "    \"O3\": dict(id=\"O3\", product=\"Gadget B\", quantity=2, price=49.99, status=\"Shipped\")}\n",
-    "\n",
-    "customers = {\n",
-    "    \"C1\": dict(name=\"John Doe\", email=\"john@example.com\", phone=\"123-456-7890\",\n",
-    "               orders=[orders['O1'], orders['O2']]),\n",
-    "    \"C2\": dict(name=\"Jane Smith\", email=\"jane@example.com\", phone=\"987-654-3210\",\n",
-    "               orders=[orders['O3']])\n",
-    "}"
+    "orders, customers = _get_orders_customers()"
    ]
   },
   {
@@ -139,7 +217,7 @@
     {
      "data": {
       "text/plain": [
-       "Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, role='assistant', function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_BYev4ExQk899v9yjLERyDGSc', function=Function(arguments='{\"customer_id\":\"C2\"}', name='get_customer_info'), type='function')]))"
+       "Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_rIx4jlrIc9YOYt04BuJQUuB3', function=Function(arguments='{\"customer_id\":\"C2\"}', name='get_customer_info'), type='function')]))"
       ]
      },
      "execution_count": null,
@@ -162,22 +240,23 @@
     {
      "data": {
       "text/markdown": [
-       "The email address for customer C2 (Jane Smith) is jane@example.com.\n",
+       "The email address for customer C2 (Jane Smith) is: jane@example.com.\n",
        "\n",
        "<details>\n",
        "\n",
-       "- id: chatcmpl-9R81d5i8pBSIRg5B7erJcF8t5BzKw\n",
-       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The email address for customer C2 (Jane Smith) is jane@example.com.', role='assistant', function_call=None, tool_calls=None))]\n",
-       "- created: 1716252733\n",
-       "- model: gpt-4o-2024-05-13\n",
+       "- id: chatcmpl-BjA0oSZlb6qWEN6nhC9itpiEsd0F5\n",
+       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The email address for customer C2 (Jane Smith) is: jane@example.com.', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))]\n",
+       "- created: 1750102946\n",
+       "- model: o4-mini-2025-04-16\n",
        "- object: chat.completion\n",
-       "- system_fingerprint: fp_729ea513f7\n",
-       "- usage: CompletionUsage(completion_tokens=17, prompt_tokens=251, total_tokens=268)\n",
+       "- service_tier: default\n",
+       "- system_fingerprint: None\n",
+       "- usage: CompletionUsage(completion_tokens=35, prompt_tokens=246, total_tokens=281, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "ChatCompletion(id='chatcmpl-9R81d5i8pBSIRg5B7erJcF8t5BzKw', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The email address for customer C2 (Jane Smith) is jane@example.com.', role='assistant', function_call=None, tool_calls=None))], created=1716252733, model='gpt-4o-2024-05-13', object='chat.completion', system_fingerprint='fp_729ea513f7', usage=In: 251; Out: 17; Total: 268)"
+       "ChatCompletion(id='chatcmpl-BjA0oSZlb6qWEN6nhC9itpiEsd0F5', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The email address for customer C2 (Jane Smith) is: jane@example.com.', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))], created=1750102946, model='o4-mini-2025-04-16', object='chat.completion', service_tier='default', system_fingerprint=None, usage=In: 246; Out: 35; Total: 281)"
       ]
      },
      "execution_count": null,
@@ -207,7 +286,7 @@
     {
      "data": {
       "text/plain": [
-       "ChatCompletionMessage(content=None, role='assistant', function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_lENp0aVeTJ7W0q8SRgC7h5s9', function=Function(arguments='{\"customer_id\":\"C1\"}', name='get_customer_info'), type='function')])"
+       "ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_5b64GsUTmKMCqb2mtqtsUXp6', function=Function(arguments='{\"customer_id\":\"C1\"}', name='get_customer_info'), type='function')])"
       ]
      },
      "execution_count": null,
@@ -223,87 +302,195 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3457eeb6",
+   "cell_type": "markdown",
+   "id": "4388cffe",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "#| exports\n",
-    "@patch\n",
-    "@delegates(Completions.create)\n",
-    "def toolloop(self:Chat,\n",
-    "             pr, # Prompt to pass to model\n",
-    "             max_steps=10, # Maximum number of tool requests to loop through\n",
-    "             trace_func:Optional[callable]=None, # Function to trace tool use steps (e.g `print`)\n",
-    "             cont_func:Optional[callable]=noop, # Function that stops loop if returns False\n",
-    "             **kwargs):\n",
-    "    \"Add prompt `pr` to dialog and get a response from the model, automatically following up with `tool_use` messages\"\n",
-    "    r = self(pr, **kwargs)\n",
-    "    for i in range(max_steps):\n",
-    "        ch = r.choices[0]\n",
-    "        if ch.finish_reason!='tool_calls': break\n",
-    "        if trace_func: trace_func(r)\n",
-    "        r = self(**kwargs)\n",
-    "        if not (cont_func or noop)(self.h[-2]): break\n",
-    "    if trace_func: trace_func(r)\n",
-    "    return r"
+    "## `toolloop` implementation"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a45d3eb0",
+   "id": "e0136903",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| exports\n",
+    "_final_prompt = \"You have no more tool uses. Please summarize your findings. If you did not complete your goal please tell the user what further work needs to be done so they can choose how best to proceed.\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "84eac4c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| exports\n",
+    "@patch\n",
+    "@delegates(Chat.__call__)\n",
+    "def toolloop(self:Chat,\n",
+    "             pr, # Prompt to pass to Claude\n",
+    "             max_steps=10, # Maximum number of tool requests to loop through\n",
+    "             cont_func:callable=noop, # Function that stops loop if returns False\n",
+    "             final_prompt=_final_prompt, # Prompt to add if last message is a tool call\n",
+    "             **kwargs):\n",
+    "    \"Add prompt `pr` to dialog and get a response from Claude, automatically following up with `tool_use` messages\"\n",
+    "    class _Loop:\n",
+    "        def __iter__(a):\n",
+    "            init_n = len(self.h)\n",
+    "            r = self(pr, **kwargs)\n",
+    "            yield r\n",
+    "            if len(self.last)>1: yield self.last[1]\n",
+    "            for i in range(max_steps-1):\n",
+    "                if r.choices[0].finish_reason != 'tool_calls': break\n",
+    "                r = self(final_prompt if i==max_steps-2 else None, **kwargs)\n",
+    "                yield r\n",
+    "                if len(self.last)>1: yield self.last[1]\n",
+    "                if not cont_func(*self.h[-3:]): break\n",
+    "            a.value = self.h[init_n+1:]\n",
+    "    return _Loop()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "491fd736",
+   "metadata": {},
+   "source": [
+    "## Test Customer Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "78cc0eff",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "- Retrieving customer C1\n",
-      "ChatCompletion(id='chatcmpl-9R81fvatrbbrAuUjZRTPKWgntsRCx', choices=[Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, role='assistant', function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_Yss1rLc1tU2wDkWPMGSGgdor', function=Function(arguments='{\"customer_id\":\"C1\"}', name='get_customer_info'), type='function')]))], created=1716252735, model='gpt-4o-2024-05-13', object='chat.completion', system_fingerprint='fp_729ea513f7', usage=In: 157; Out: 17; Total: 174)\n",
-      "- Cancelling order O1\n",
-      "- Cancelling order O2\n",
-      "ChatCompletion(id='chatcmpl-9R81gjtdy8L3cUI4o46MDeeOdaaRb', choices=[Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, role='assistant', function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_4AIzkbEYXTGNqd6uMsPLuVEB', function=Function(arguments='{\"order_id\": \"O1\"}', name='cancel_order'), type='function'), ChatCompletionMessageToolCall(id='call_Px4E3w1qEJZCIrU5ymf6qsNt', function=Function(arguments='{\"order_id\": \"O2\"}', name='cancel_order'), type='function')]))], created=1716252736, model='gpt-4o-2024-05-13', object='chat.completion', system_fingerprint='fp_729ea513f7', usage=In: 283; Out: 48; Total: 331)\n",
-      "ChatCompletion(id='chatcmpl-9R81hQpOI0m1ExNidpdMrIiMx78pd', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Both orders for customer C1 have been successfully canceled.', role='assistant', function_call=None, tool_calls=None))], created=1716252737, model='gpt-4o-2024-05-13', object='chat.completion', system_fingerprint='fp_729ea513f7', usage=In: 347; Out: 12; Total: 359)\n"
+      "- Retrieving customer C1\n"
      ]
     },
     {
      "data": {
       "text/markdown": [
-       "Both orders for customer C1 have been successfully canceled.\n",
+       "- id: chatcmpl-BjA16YUSVRETf3MKfZhvOSToAGL3u\n",
+       "- choices: [Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_H0kNomg5F0wVqiR8EDSu2aWn', function=Function(arguments='{\"customer_id\":\"C1\"}', name='get_customer_info'), type='function')]))]\n",
+       "- created: 1750102964\n",
+       "- model: o4-mini-2025-04-16\n",
+       "- object: chat.completion\n",
+       "- service_tier: default\n",
+       "- system_fingerprint: None\n",
+       "- usage: CompletionUsage(completion_tokens=26, prompt_tokens=147, total_tokens=173, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))"
+      ],
+      "text/plain": [
+       "ChatCompletion(id='chatcmpl-BjA16YUSVRETf3MKfZhvOSToAGL3u', choices=[Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_H0kNomg5F0wVqiR8EDSu2aWn', function=Function(arguments='{\"customer_id\":\"C1\"}', name='get_customer_info'), type='function')]))], created=1750102964, model='o4-mini-2025-04-16', object='chat.completion', service_tier='default', system_fingerprint=None, usage=In: 147; Out: 26; Total: 173)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "```json\n",
+       "{ 'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': \"\n",
+       "             \"'123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', \"\n",
+       "             \"'quantity': 2, 'price': 19.99, 'status': 'Cancelled'}, {'id': \"\n",
+       "             \"'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, \"\n",
+       "             \"'status': 'Cancelled'}]}\",\n",
+       "  'name': 'get_customer_info',\n",
+       "  'role': 'tool',\n",
+       "  'tool_call_id': 'call_H0kNomg5F0wVqiR8EDSu2aWn'}\n",
+       "```"
+      ],
+      "text/plain": [
+       "{'role': 'tool',\n",
+       " 'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': '123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', 'quantity': 2, 'price': 19.99, 'status': 'Cancelled'}, {'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Cancelled'}]}\",\n",
+       " 'tool_call_id': 'call_H0kNomg5F0wVqiR8EDSu2aWn',\n",
+       " 'name': 'get_customer_info'}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "The email address for customer C1 is john@example.com.\n",
        "\n",
        "<details>\n",
        "\n",
-       "- id: chatcmpl-9R81hQpOI0m1ExNidpdMrIiMx78pd\n",
-       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Both orders for customer C1 have been successfully canceled.', role='assistant', function_call=None, tool_calls=None))]\n",
-       "- created: 1716252737\n",
-       "- model: gpt-4o-2024-05-13\n",
+       "- id: chatcmpl-BjA18DXRyQQq88cKBavOGEn4SCkJC\n",
+       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The email address for customer C1 is john@example.com.', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))]\n",
+       "- created: 1750102966\n",
+       "- model: o4-mini-2025-04-16\n",
        "- object: chat.completion\n",
-       "- system_fingerprint: fp_729ea513f7\n",
-       "- usage: CompletionUsage(completion_tokens=12, prompt_tokens=347, total_tokens=359)\n",
+       "- service_tier: default\n",
+       "- system_fingerprint: None\n",
+       "- usage: CompletionUsage(completion_tokens=30, prompt_tokens=278, total_tokens=308, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "ChatCompletion(id='chatcmpl-9R81hQpOI0m1ExNidpdMrIiMx78pd', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Both orders for customer C1 have been successfully canceled.', role='assistant', function_call=None, tool_calls=None))], created=1716252737, model='gpt-4o-2024-05-13', object='chat.completion', system_fingerprint='fp_729ea513f7', usage=In: 347; Out: 12; Total: 359)"
+       "ChatCompletion(id='chatcmpl-BjA18DXRyQQq88cKBavOGEn4SCkJC', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The email address for customer C1 is john@example.com.', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))], created=1750102966, model='o4-mini-2025-04-16', object='chat.completion', service_tier='default', system_fingerprint=None, usage=In: 278; Out: 30; Total: 308)"
       ]
      },
-     "execution_count": null,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
     "chat = Chat(model, tools=tools)\n",
-    "r = chat.toolloop('Please cancel all orders for customer C1 for me.', trace_func=print)\n",
-    "r"
+    "pr = 'Can you tell me the email address for customer C1?'\n",
+    "r = chat.toolloop(pr)\n",
+    "for o in r: display(o)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "592e9084",
+   "id": "5c586d6a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_H0kNomg5F0wVqiR8EDSu2aWn', function=Function(arguments='{\"customer_id\":\"C1\"}', name='get_customer_info'), type='function')]),\n",
+      " {'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': \"\n",
+      "             \"'123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', \"\n",
+      "             \"'quantity': 2, 'price': 19.99, 'status': 'Cancelled'}, {'id': \"\n",
+      "             \"'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, \"\n",
+      "             \"'status': 'Cancelled'}]}\",\n",
+      "  'name': 'get_customer_info',\n",
+      "  'role': 'tool',\n",
+      "  'tool_call_id': 'call_H0kNomg5F0wVqiR8EDSu2aWn'},\n",
+      " ChatCompletionMessage(content='The email address for customer C1 is john@example.com.', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None)]\n"
+     ]
+    }
+   ],
+   "source": [
+    "pprint(r.value)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "050f6591",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "orders, customers = _get_orders_customers()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8de04256",
    "metadata": {},
    "outputs": [
     {
@@ -316,22 +503,499 @@
     {
      "data": {
       "text/markdown": [
-       "The status of order O2 is \"Cancelled\".\n",
+       "- id: chatcmpl-BjA1AQNdi4SF9WAxeT66NDCTXhQwE\n",
+       "- choices: [Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_7I3ugfxBZbhApKLgkhpH3pQf', function=Function(arguments='{\"order_id\":\"O2\"}', name='get_order_details'), type='function')]))]\n",
+       "- created: 1750102968\n",
+       "- model: o4-mini-2025-04-16\n",
+       "- object: chat.completion\n",
+       "- service_tier: default\n",
+       "- system_fingerprint: None\n",
+       "- usage: CompletionUsage(completion_tokens=26, prompt_tokens=144, total_tokens=170, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))"
+      ],
+      "text/plain": [
+       "ChatCompletion(id='chatcmpl-BjA1AQNdi4SF9WAxeT66NDCTXhQwE', choices=[Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_7I3ugfxBZbhApKLgkhpH3pQf', function=Function(arguments='{\"order_id\":\"O2\"}', name='get_order_details'), type='function')]))], created=1750102968, model='o4-mini-2025-04-16', object='chat.completion', service_tier='default', system_fingerprint=None, usage=In: 144; Out: 26; Total: 170)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "```json\n",
+       "{ 'content': \"{'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': \"\n",
+       "             \"49.99, 'status': 'Processing'}\",\n",
+       "  'name': 'get_order_details',\n",
+       "  'role': 'tool',\n",
+       "  'tool_call_id': 'call_7I3ugfxBZbhApKLgkhpH3pQf'}\n",
+       "```"
+      ],
+      "text/plain": [
+       "{'role': 'tool',\n",
+       " 'content': \"{'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Processing'}\",\n",
+       " 'tool_call_id': 'call_7I3ugfxBZbhApKLgkhpH3pQf',\n",
+       " 'name': 'get_order_details'}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "The status of order O2 is “Processing.”\n",
        "\n",
        "<details>\n",
        "\n",
-       "- id: chatcmpl-9R81inXsiw5xzoux1xw5Z7bBoPsuN\n",
-       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The status of order O2 is \"Cancelled\".', role='assistant', function_call=None, tool_calls=None))]\n",
-       "- created: 1716252738\n",
-       "- model: gpt-4o-2024-05-13\n",
+       "- id: chatcmpl-BjA1C5TznRspip7U7eAl7Re7xUIey\n",
+       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The status of order O2 is “Processing.”', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))]\n",
+       "- created: 1750102970\n",
+       "- model: o4-mini-2025-04-16\n",
        "- object: chat.completion\n",
-       "- system_fingerprint: fp_729ea513f7\n",
-       "- usage: CompletionUsage(completion_tokens=11, prompt_tokens=436, total_tokens=447)\n",
+       "- service_tier: default\n",
+       "- system_fingerprint: None\n",
+       "- usage: CompletionUsage(completion_tokens=22, prompt_tokens=211, total_tokens=233, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
        "\n",
        "</details>"
       ],
       "text/plain": [
-       "ChatCompletion(id='chatcmpl-9R81inXsiw5xzoux1xw5Z7bBoPsuN', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The status of order O2 is \"Cancelled\".', role='assistant', function_call=None, tool_calls=None))], created=1716252738, model='gpt-4o-2024-05-13', object='chat.completion', system_fingerprint='fp_729ea513f7', usage=In: 436; Out: 11; Total: 447)"
+       "ChatCompletion(id='chatcmpl-BjA1C5TznRspip7U7eAl7Re7xUIey', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The status of order O2 is “Processing.”', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))], created=1750102970, model='o4-mini-2025-04-16', object='chat.completion', service_tier='default', system_fingerprint=None, usage=In: 211; Out: 22; Total: 233)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "chat = Chat(model, tools=tools)\n",
+    "r = chat.toolloop('What is the status of order O2?')\n",
+    "for o in r: display(o)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8c0fec9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "- Retrieving customer C1\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "- id: chatcmpl-BjA1DkRjKa0BOV0xQKmgeaHISzcbT\n",
+       "- choices: [Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_rGJnn2TY03odl0yot4Lcbk6R', function=Function(arguments='{\"customer_id\":\"C1\"}', name='get_customer_info'), type='function')]))]\n",
+       "- created: 1750102971\n",
+       "- model: o4-mini-2025-04-16\n",
+       "- object: chat.completion\n",
+       "- service_tier: default\n",
+       "- system_fingerprint: None\n",
+       "- usage: CompletionUsage(completion_tokens=218, prompt_tokens=242, total_tokens=460, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=192, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))"
+      ],
+      "text/plain": [
+       "ChatCompletion(id='chatcmpl-BjA1DkRjKa0BOV0xQKmgeaHISzcbT', choices=[Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_rGJnn2TY03odl0yot4Lcbk6R', function=Function(arguments='{\"customer_id\":\"C1\"}', name='get_customer_info'), type='function')]))], created=1750102971, model='o4-mini-2025-04-16', object='chat.completion', service_tier='default', system_fingerprint=None, usage=In: 242; Out: 218; Total: 460)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "```json\n",
+       "{ 'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': \"\n",
+       "             \"'123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', \"\n",
+       "             \"'quantity': 2, 'price': 19.99, 'status': 'Shipped'}, {'id': \"\n",
+       "             \"'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, \"\n",
+       "             \"'status': 'Processing'}]}\",\n",
+       "  'name': 'get_customer_info',\n",
+       "  'role': 'tool',\n",
+       "  'tool_call_id': 'call_rGJnn2TY03odl0yot4Lcbk6R'}\n",
+       "```"
+      ],
+      "text/plain": [
+       "{'role': 'tool',\n",
+       " 'content': \"{'name': 'John Doe', 'email': 'john@example.com', 'phone': '123-456-7890', 'orders': [{'id': 'O1', 'product': 'Widget A', 'quantity': 2, 'price': 19.99, 'status': 'Shipped'}, {'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Processing'}]}\",\n",
+       " 'tool_call_id': 'call_rGJnn2TY03odl0yot4Lcbk6R',\n",
+       " 'name': 'get_customer_info'}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "- Cancelling order O1\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "- id: chatcmpl-BjA1HTq3pyutXIeCIP47aDSyPWqs9\n",
+       "- choices: [Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_JWB8rjsYpoWBdmyz6MPPPVZU', function=Function(arguments='{\"order_id\":\"O1\"}', name='cancel_order'), type='function')]))]\n",
+       "- created: 1750102975\n",
+       "- model: o4-mini-2025-04-16\n",
+       "- object: chat.completion\n",
+       "- service_tier: default\n",
+       "- system_fingerprint: None\n",
+       "- usage: CompletionUsage(completion_tokens=217, prompt_tokens=374, total_tokens=591, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=192, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))"
+      ],
+      "text/plain": [
+       "ChatCompletion(id='chatcmpl-BjA1HTq3pyutXIeCIP47aDSyPWqs9', choices=[Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_JWB8rjsYpoWBdmyz6MPPPVZU', function=Function(arguments='{\"order_id\":\"O1\"}', name='cancel_order'), type='function')]))], created=1750102975, model='o4-mini-2025-04-16', object='chat.completion', service_tier='default', system_fingerprint=None, usage=In: 374; Out: 217; Total: 591)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "```json\n",
+       "{ 'content': 'True',\n",
+       "  'name': 'cancel_order',\n",
+       "  'role': 'tool',\n",
+       "  'tool_call_id': 'call_JWB8rjsYpoWBdmyz6MPPPVZU'}\n",
+       "```"
+      ],
+      "text/plain": [
+       "{'role': 'tool',\n",
+       " 'content': 'True',\n",
+       " 'tool_call_id': 'call_JWB8rjsYpoWBdmyz6MPPPVZU',\n",
+       " 'name': 'cancel_order'}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "- Cancelling order O2\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "- id: chatcmpl-BjA1Khf8gjWTUV82pzgxDs4zJ0pFp\n",
+       "- choices: [Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_Eq2CHHP881RPwaoOvuIjlfwL', function=Function(arguments='{\"order_id\":\"O2\"}', name='cancel_order'), type='function')]))]\n",
+       "- created: 1750102978\n",
+       "- model: o4-mini-2025-04-16\n",
+       "- object: chat.completion\n",
+       "- service_tier: default\n",
+       "- system_fingerprint: None\n",
+       "- usage: CompletionUsage(completion_tokens=217, prompt_tokens=405, total_tokens=622, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=192, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))"
+      ],
+      "text/plain": [
+       "ChatCompletion(id='chatcmpl-BjA1Khf8gjWTUV82pzgxDs4zJ0pFp', choices=[Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_Eq2CHHP881RPwaoOvuIjlfwL', function=Function(arguments='{\"order_id\":\"O2\"}', name='cancel_order'), type='function')]))], created=1750102978, model='o4-mini-2025-04-16', object='chat.completion', service_tier='default', system_fingerprint=None, usage=In: 405; Out: 217; Total: 622)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "```json\n",
+       "{ 'content': 'True',\n",
+       "  'name': 'cancel_order',\n",
+       "  'role': 'tool',\n",
+       "  'tool_call_id': 'call_Eq2CHHP881RPwaoOvuIjlfwL'}\n",
+       "```"
+      ],
+      "text/plain": [
+       "{'role': 'tool',\n",
+       " 'content': 'True',\n",
+       " 'tool_call_id': 'call_Eq2CHHP881RPwaoOvuIjlfwL',\n",
+       " 'name': 'cancel_order'}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "Both orders for customer C1 have been successfully canceled:\n",
+       "\n",
+       "- Order O1: Canceled  \n",
+       "- Order O2: Canceled\n",
+       "\n",
+       "Let me know if there’s anything else I can help you with!\n",
+       "\n",
+       "<details>\n",
+       "\n",
+       "- id: chatcmpl-BjA1PFmlPuLUomaKvYxaJOlgCtABE\n",
+       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Both orders for customer C1 have been successfully canceled:\\n\\n- Order O1: Canceled  \\n- Order O2: Canceled\\n\\nLet me know if there’s anything else I can help you with!', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))]\n",
+       "- created: 1750102983\n",
+       "- model: o4-mini-2025-04-16\n",
+       "- object: chat.completion\n",
+       "- service_tier: default\n",
+       "- system_fingerprint: None\n",
+       "- usage: CompletionUsage(completion_tokens=53, prompt_tokens=436, total_tokens=489, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
+       "\n",
+       "</details>"
+      ],
+      "text/plain": [
+       "ChatCompletion(id='chatcmpl-BjA1PFmlPuLUomaKvYxaJOlgCtABE', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='Both orders for customer C1 have been successfully canceled:\\n\\n- Order O1: Canceled  \\n- Order O2: Canceled\\n\\nLet me know if there’s anything else I can help you with!', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))], created=1750102983, model='o4-mini-2025-04-16', object='chat.completion', service_tier='default', system_fingerprint=None, usage=In: 436; Out: 53; Total: 489)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "r = chat.toolloop('Please cancel all orders for customer C1 for me.')\n",
+    "for o in r: display(o)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2421d39d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "- Retrieving order O2\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "- id: chatcmpl-BjA1QvyErrb3Rg9yra6vC8KxlPg65\n",
+       "- choices: [Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_75RFqe2Nm8sxT5SxsDhn5Fyz', function=Function(arguments='{\"order_id\":\"O2\"}', name='get_order_details'), type='function')]))]\n",
+       "- created: 1750102984\n",
+       "- model: o4-mini-2025-04-16\n",
+       "- object: chat.completion\n",
+       "- service_tier: default\n",
+       "- system_fingerprint: None\n",
+       "- usage: CompletionUsage(completion_tokens=218, prompt_tokens=496, total_tokens=714, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=192, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))"
+      ],
+      "text/plain": [
+       "ChatCompletion(id='chatcmpl-BjA1QvyErrb3Rg9yra6vC8KxlPg65', choices=[Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_75RFqe2Nm8sxT5SxsDhn5Fyz', function=Function(arguments='{\"order_id\":\"O2\"}', name='get_order_details'), type='function')]))], created=1750102984, model='o4-mini-2025-04-16', object='chat.completion', service_tier='default', system_fingerprint=None, usage=In: 496; Out: 218; Total: 714)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "```json\n",
+       "{ 'content': \"{'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': \"\n",
+       "             \"49.99, 'status': 'Cancelled'}\",\n",
+       "  'name': 'get_order_details',\n",
+       "  'role': 'tool',\n",
+       "  'tool_call_id': 'call_75RFqe2Nm8sxT5SxsDhn5Fyz'}\n",
+       "```"
+      ],
+      "text/plain": [
+       "{'role': 'tool',\n",
+       " 'content': \"{'id': 'O2', 'product': 'Gadget B', 'quantity': 1, 'price': 49.99, 'status': 'Cancelled'}\",\n",
+       " 'tool_call_id': 'call_75RFqe2Nm8sxT5SxsDhn5Fyz',\n",
+       " 'name': 'get_order_details'}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "The status of order O2 is now “Cancelled.”\n",
+       "\n",
+       "<details>\n",
+       "\n",
+       "- id: chatcmpl-BjA1S4PoZEyLOKEU4KDl24hTYUTMx\n",
+       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The status of order O2 is now “Cancelled.”', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))]\n",
+       "- created: 1750102986\n",
+       "- model: o4-mini-2025-04-16\n",
+       "- object: chat.completion\n",
+       "- service_tier: default\n",
+       "- system_fingerprint: None\n",
+       "- usage: CompletionUsage(completion_tokens=23, prompt_tokens=563, total_tokens=586, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
+       "\n",
+       "</details>"
+      ],
+      "text/plain": [
+       "ChatCompletion(id='chatcmpl-BjA1S4PoZEyLOKEU4KDl24hTYUTMx', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='The status of order O2 is now “Cancelled.”', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))], created=1750102986, model='o4-mini-2025-04-16', object='chat.completion', service_tier='default', system_fingerprint=None, usage=In: 563; Out: 23; Total: 586)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "for o in chat.toolloop('What is the status of order O2?'): display(o)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72f73ae2",
+   "metadata": {},
+   "source": [
+    "## Test Math Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0fd52dbc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def add(x: int, y: int) -> int:\n",
+    "    \"adds x and y.\"\n",
+    "    return x + y\n",
+    "\n",
+    "def mul(x: int, y: int) -> int:\n",
+    "    \"multiplies x and y.\"\n",
+    "    return x * y"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1cc19bf",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "- id: chatcmpl-BjA1U9JzEL7oTfQfq3CNyksPDzt83\n",
+       "- choices: [Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_zlFxReIvYCeqMETgqcpMbqqu', function=Function(arguments='{\"x\":1258585825128,\"y\":34959234595}', name='add'), type='function')]))]\n",
+       "- created: 1750102988\n",
+       "- model: o4-mini-2025-04-16\n",
+       "- object: chat.completion\n",
+       "- service_tier: default\n",
+       "- system_fingerprint: None\n",
+       "- usage: CompletionUsage(completion_tokens=1121, prompt_tokens=112, total_tokens=1233, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=1088, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))"
+      ],
+      "text/plain": [
+       "ChatCompletion(id='chatcmpl-BjA1U9JzEL7oTfQfq3CNyksPDzt83', choices=[Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_zlFxReIvYCeqMETgqcpMbqqu', function=Function(arguments='{\"x\":1258585825128,\"y\":34959234595}', name='add'), type='function')]))], created=1750102988, model='o4-mini-2025-04-16', object='chat.completion', service_tier='default', system_fingerprint=None, usage=In: 112; Out: 1121; Total: 1233)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "```json\n",
+       "{ 'content': '1293545059723',\n",
+       "  'name': 'add',\n",
+       "  'role': 'tool',\n",
+       "  'tool_call_id': 'call_zlFxReIvYCeqMETgqcpMbqqu'}\n",
+       "```"
+      ],
+      "text/plain": [
+       "{'role': 'tool',\n",
+       " 'content': '1293545059723',\n",
+       " 'tool_call_id': 'call_zlFxReIvYCeqMETgqcpMbqqu',\n",
+       " 'name': 'add'}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "- id: chatcmpl-BjA1efe2c7CKKX8F0EcIa19GTSvCG\n",
+       "- choices: [Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_WZfBhr0j9G3JWhue9lFQSK86', function=Function(arguments='{\"x\":1293545059723,\"y\":93}', name='mul'), type='function')]))]\n",
+       "- created: 1750102998\n",
+       "- model: o4-mini-2025-04-16\n",
+       "- object: chat.completion\n",
+       "- service_tier: default\n",
+       "- system_fingerprint: None\n",
+       "- usage: CompletionUsage(completion_tokens=24, prompt_tokens=154, total_tokens=178, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))"
+      ],
+      "text/plain": [
+       "ChatCompletion(id='chatcmpl-BjA1efe2c7CKKX8F0EcIa19GTSvCG', choices=[Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_WZfBhr0j9G3JWhue9lFQSK86', function=Function(arguments='{\"x\":1293545059723,\"y\":93}', name='mul'), type='function')]))], created=1750102998, model='o4-mini-2025-04-16', object='chat.completion', service_tier='default', system_fingerprint=None, usage=In: 154; Out: 24; Total: 178)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "```json\n",
+       "{ 'content': '120299690554239',\n",
+       "  'name': 'mul',\n",
+       "  'role': 'tool',\n",
+       "  'tool_call_id': 'call_WZfBhr0j9G3JWhue9lFQSK86'}\n",
+       "```"
+      ],
+      "text/plain": [
+       "{'role': 'tool',\n",
+       " 'content': '120299690554239',\n",
+       " 'tool_call_id': 'call_WZfBhr0j9G3JWhue9lFQSK86',\n",
+       " 'name': 'mul'}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "First, we computed:\n",
+       "\n",
+       "1. 1258585825128 + 34 959 234 595 = 1 293 545 059 723  \n",
+       "2. 1 293 545 059 723 × 93 = 120 299 690 554 239  \n",
+       "3. 120 299 690 554 239 + (–12 439 149) = 120 299 678 115 090  \n",
+       "\n",
+       "So the final result is 120299678115090.\n",
+       "\n",
+       "<details>\n",
+       "\n",
+       "- id: chatcmpl-BjA1f2IVdmLXuktSK6et0oJoibPWn\n",
+       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='First, we computed:\\n\\n1. 1258585825128 + 34 959 234 595 = 1 293 545 059 723  \\n2. 1 293 545 059 723 × 93 = 120 299 690 554 239  \\n3. 120 299 690 554 239 + (–12 439 149) = 120 299 678 115 090  \\n\\nSo the final result is 120299678115090.', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))]\n",
+       "- created: 1750102999\n",
+       "- model: o4-mini-2025-04-16\n",
+       "- object: chat.completion\n",
+       "- service_tier: default\n",
+       "- system_fingerprint: None\n",
+       "- usage: CompletionUsage(completion_tokens=316, prompt_tokens=193, total_tokens=509, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=192, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
+       "\n",
+       "</details>"
+      ],
+      "text/plain": [
+       "ChatCompletion(id='chatcmpl-BjA1f2IVdmLXuktSK6et0oJoibPWn', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='First, we computed:\\n\\n1. 1258585825128 + 34 959 234 595 = 1 293 545 059 723  \\n2. 1 293 545 059 723 × 93 = 120 299 690 554 239  \\n3. 120 299 690 554 239 + (–12 439 149) = 120 299 678 115 090  \\n\\nSo the final result is 120299678115090.', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))], created=1750102999, model='o4-mini-2025-04-16', object='chat.completion', service_tier='default', system_fingerprint=None, usage=In: 193; Out: 316; Total: 509)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "chat = Chat(model, tools=[add, mul])\n",
+    "pr = 'Can you add 1258585825128 to 34959234595, multiply by 93, and then add - 12439149?'\n",
+    "r = chat.toolloop(pr)\n",
+    "for o in r: display(o)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5fdc44e8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "120299678115090"
       ]
      },
      "execution_count": null,
@@ -340,7 +1004,153 @@
     }
    ],
    "source": [
-    "chat.toolloop('What is the status of order O2?')"
+    "(1258585825128 + 34959234595) * 93 - 12439149"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e95da200",
+   "metadata": {},
+   "source": [
+    "## Test Error Conditions: Out of Iterations, Exception During Tool Invocation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "82c63e59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def mydiv(a:float, b:float):\n",
+    "    \"Divide two numbers\"\n",
+    "    return a / b"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26bc1bd9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "- id: chatcmpl-BjA1krNKBzPL83FEgM6jLlREsezt3\n",
+       "- choices: [Choice(finish_reason='length', index=0, logprobs=None, message=ChatCompletionMessage(content='', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))]\n",
+       "- created: 1750103004\n",
+       "- model: o4-mini-2025-04-16\n",
+       "- object: chat.completion\n",
+       "- service_tier: default\n",
+       "- system_fingerprint: None\n",
+       "- usage: CompletionUsage(completion_tokens=4096, prompt_tokens=77, total_tokens=4173, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=4096, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))"
+      ],
+      "text/plain": [
+       "ChatCompletion(id='chatcmpl-BjA1krNKBzPL83FEgM6jLlREsezt3', choices=[Choice(finish_reason='length', index=0, logprobs=None, message=ChatCompletionMessage(content='', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))], created=1750103004, model='o4-mini-2025-04-16', object='chat.completion', service_tier='default', system_fingerprint=None, usage=In: 77; Out: 4096; Total: 4173)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "chat = Chat(model, tools=[mydiv])\n",
+    "r = chat.toolloop('Please calculate this sequence using your tools: 43/23454; 652/previous result; 6843/previous result; 321/previous result', max_steps=2)\n",
+    "for o in r: display(o)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf6178b8",
+   "metadata": {},
+   "source": [
+    "This tests `raise_on_err=False` change to `toolslm.call_func` invocation. We should see this return an error as a string instead of crash:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "730cbb2c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "- id: chatcmpl-BjA2bgViq8n8CPimn1niDb8gVfYuX\n",
+       "- choices: [Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_dNL7NWhb44HN7HrvanBNqxfm', function=Function(arguments='{\"a\":1,\"b\":0}', name='mydiv'), type='function')]))]\n",
+       "- created: 1750103057\n",
+       "- model: o4-mini-2025-04-16\n",
+       "- object: chat.completion\n",
+       "- service_tier: default\n",
+       "- system_fingerprint: None\n",
+       "- usage: CompletionUsage(completion_tokens=155, prompt_tokens=59, total_tokens=214, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=128, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))"
+      ],
+      "text/plain": [
+       "ChatCompletion(id='chatcmpl-BjA2bgViq8n8CPimn1niDb8gVfYuX', choices=[Choice(finish_reason='tool_calls', index=0, logprobs=None, message=ChatCompletionMessage(content=None, refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=[ChatCompletionMessageToolCall(id='call_dNL7NWhb44HN7HrvanBNqxfm', function=Function(arguments='{\"a\":1,\"b\":0}', name='mydiv'), type='function')]))], created=1750103057, model='o4-mini-2025-04-16', object='chat.completion', service_tier='default', system_fingerprint=None, usage=In: 59; Out: 155; Total: 214)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "```json\n",
+       "{ 'content': 'Traceback (most recent call last):\\n'\n",
+       "             '  File '\n",
+       "             '\"/home/austin/projects/aai-ws/toolslm/toolslm/funccall.py\", line '\n",
+       "             '198, in call_func\\n'\n",
+       "             '    try: return func(**fc_inputs)\\n'\n",
+       "             '                ^^^^^^^^^^^^^^^^^\\n'\n",
+       "             '  File \"/tmp/ipykernel_199809/246724137.py\", line 3, in mydiv\\n'\n",
+       "             '    return a / b\\n'\n",
+       "             '           ~~^~~\\n'\n",
+       "             'ZeroDivisionError: division by zero\\n',\n",
+       "  'name': 'mydiv',\n",
+       "  'role': 'tool',\n",
+       "  'tool_call_id': 'call_dNL7NWhb44HN7HrvanBNqxfm'}\n",
+       "```"
+      ],
+      "text/plain": [
+       "{'role': 'tool',\n",
+       " 'content': 'Traceback (most recent call last):\\n  File \"/home/austin/projects/aai-ws/toolslm/toolslm/funccall.py\", line 198, in call_func\\n    try: return func(**fc_inputs)\\n                ^^^^^^^^^^^^^^^^^\\n  File \"/tmp/ipykernel_199809/246724137.py\", line 3, in mydiv\\n    return a / b\\n           ~~^~~\\nZeroDivisionError: division by zero\\n',\n",
+       " 'tool_call_id': 'call_dNL7NWhb44HN7HrvanBNqxfm',\n",
+       " 'name': 'mydiv'}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "When attempting to divide 1 by 0, a ZeroDivisionError is raised with the message: \"division by zero.\"\n",
+       "\n",
+       "<details>\n",
+       "\n",
+       "- id: chatcmpl-BjA2eXvC8ciyiOF3ez7jqCXshr1Rd\n",
+       "- choices: [Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='When attempting to divide 1 by 0, a ZeroDivisionError is raised with the message: \"division by zero.\"', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))]\n",
+       "- created: 1750103060\n",
+       "- model: o4-mini-2025-04-16\n",
+       "- object: chat.completion\n",
+       "- service_tier: default\n",
+       "- system_fingerprint: None\n",
+       "- usage: CompletionUsage(completion_tokens=37, prompt_tokens=187, total_tokens=224, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n",
+       "\n",
+       "</details>"
+      ],
+      "text/plain": [
+       "ChatCompletion(id='chatcmpl-BjA2eXvC8ciyiOF3ez7jqCXshr1Rd', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='When attempting to divide 1 by 0, a ZeroDivisionError is raised with the message: \"division by zero.\"', refusal=None, role='assistant', annotations=[], audio=None, function_call=None, tool_calls=None))], created=1750103060, model='o4-mini-2025-04-16', object='chat.completion', service_tier='default', system_fingerprint=None, usage=In: 187; Out: 37; Total: 224)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "chat = Chat(model, tools=[mydiv])\n",
+    "r = chat.toolloop('Try dividing 1 by 0 and see what the error result is')\n",
+    "for o in r: display(o)"
    ]
   },
   {


### PR DESCRIPTION
This PR updates `cosette` with the iterator implementation of `toolloop` and other more recent changes to `claudette`.

- update `toolloop` to match claudette iterator implementation
- handle errors as string using raise_on_err
- add `.last` field to Chat
- listify `Chat.tools` initializer arg
- add newer models - o1-pro, o3, o4-mini
- add additional tests to toolloop notebook.