### PR TITLE
Use json.loads for func args instead of ast.literal_eval

### DIFF
--- a/00_core.ipynb
+++ b/00_core.ipynb
@@ -38,7 +38,7 @@
     "from fastcore.utils import *\n",
     "from fastcore.meta import delegates\n",
     "\n",
-    "import inspect, typing, mimetypes, base64, json, ast, msglm\n",
+    "import inspect, typing, mimetypes, base64, json, msglm\n",
     "from collections import abc\n",
     "from random import choices\n",
     "from string import ascii_letters,digits\n",
@@ -1466,7 +1466,7 @@
    "source": [
     "#| exports\n",
     "def call_func_openai(func, ns:Optional[abc.Mapping]=None):\n",
-    "    return call_func(func.name, ast.literal_eval(func.arguments), ns, raise_on_err=False)"
+    "    return call_func(func.name, json.loads(func.arguments), ns, raise_on_err=False)"
    ]
   },
   {

--- a/cosette/core.py
+++ b/cosette/core.py
@@ -14,7 +14,7 @@ from fastcore import imghdr
 from fastcore.utils import *
 from fastcore.meta import delegates
 
-import inspect, typing, mimetypes, base64, json, ast, msglm
+import inspect, typing, mimetypes, base64, json, msglm
 from collections import abc
 from random import choices
 from string import ascii_letters,digits
@@ -163,7 +163,7 @@ def __call__(self:Client,
 
 # %% ../00_core.ipynb
 def call_func_openai(func, ns:Optional[abc.Mapping]=None):
-    return call_func(func.name, ast.literal_eval(func.arguments), ns, raise_on_err=False)
+    return call_func(func.name, json.loads(func.arguments), ns, raise_on_err=False)
 
 # %% ../00_core.ipynb
 def _toolres(r, ns):

--- a/llms-ctx-full.txt
+++ b/llms-ctx-full.txt
@@ -1874,7 +1874,7 @@ target="_blank" style="float:right; font-size:smaller">source</a>
 
 ``` python
 def call_func_openai(func:types.chat.chat_completion_message_tool_call.Function, ns:Optional[abc.Mapping]=None):
-    return call_func(func.name, ast.literal_eval(func.arguments), ns)
+    return call_func(func.name, json.loads(func.arguments), ns)
 ```
 
 </details>


### PR DESCRIPTION
OpenAI function arguments are returned as JSON strings. While `ast.literal_eval` works for many cases, `json.loads` is the correct parser for JSON data and handles all valid JSON properly.

Changes:
- Replace `ast.literal_eval` with `json.loads` in `call_func_openai`.
- Remove unused `ast` import.

This ensures function arguments are parsed correctly according to the JSON spec.